### PR TITLE
rp cut implementation for analytic counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,12 @@ See [pycorr docs](https://py2pcf.readthedocs.io/en/latest/user/building.html).
 
 ## Acknowledgments
 
-- Lehman Garrison and Manodeep Sinha for advice when implementing linear binning, and PIP and angular weights into Corrfunc.
-- Davide Bianchi for cross-checks of two-point counts with PIP weights.
-- Svyatoslav Trusov for script to compute jackknife covariance estimates based on https://arxiv.org/pdf/2109.07071.pdf: https://github.com/theonefromnowhere/JK_pycorr/blob/main/CF_JK_ST_conf.py.
+- Lehman Garrison and Manodeep Sinha for advice when implementing linear binning, and PIP and angular weights into Corrfunc
+- Davide Bianchi for cross-checks of two-point counts with PIP weights
+- Svyatoslav Trusov for script to compute jackknife covariance estimates based on https://arxiv.org/pdf/2109.07071.pdf: https://github.com/theonefromnowhere/JK_pycorr/blob/main/CF_JK_ST_conf.py
 - Enrique Paillas and Seshadri Nadathur for suggestions about reconstructed 2pcf measurements
 - Craig Warner for GPU-izing Corrfunc 'smu' counts
+- Misha Rashkovetskyi for rp-cut analytical pair counts
 - Craig Warner, James Lasker, Misha Rashkovetskyi and Edmond Chaussidon for spotting typos / bug reports
 
 # Citations

--- a/pycorr/correlation_function.py
+++ b/pycorr/correlation_function.py
@@ -364,7 +364,7 @@ def TwoPointCorrelationFunction(mode, edges, data_positions1, data_positions2=No
                 size2 = counts['D1D2'].size2
             if boxsize is None:
                 raise ValueError('boxsize must be provided for analytic two-point counts {}.'.format(label12))
-            counts[label12] = AnalyticTwoPointCounter(mode, edges, boxsize, size1=size1, size2=size2, selection_attrs=selection_attrs)
+            counts[label12] = AnalyticTwoPointCounter(mode, edges, boxsize, size1=size1, size2=size2, selection_attrs=selection_attrs[label12])
             continue
         if log: logger.info('Computing two-point counts {}.'.format(label12))
         twopoint_kwargs = {'twopoint_weights': twopoint_weights[label12], 'weight_type': weight_type[label12], 'selection_attrs': selection_attrs[label12]}

--- a/pycorr/correlation_function.py
+++ b/pycorr/correlation_function.py
@@ -364,7 +364,7 @@ def TwoPointCorrelationFunction(mode, edges, data_positions1, data_positions2=No
                 size2 = counts['D1D2'].size2
             if boxsize is None:
                 raise ValueError('boxsize must be provided for analytic two-point counts {}.'.format(label12))
-            counts[label12] = AnalyticTwoPointCounter(mode, edges, boxsize, size1=size1, size2=size2)
+            counts[label12] = AnalyticTwoPointCounter(mode, edges, boxsize, size1=size1, size2=size2, selection_attrs=selection_attrs)
             continue
         if log: logger.info('Computing two-point counts {}.'.format(label12))
         twopoint_kwargs = {'twopoint_weights': twopoint_weights[label12], 'weight_type': weight_type[label12], 'selection_attrs': selection_attrs[label12]}

--- a/pycorr/twopoint_counter.py
+++ b/pycorr/twopoint_counter.py
@@ -1429,7 +1429,7 @@ class AnalyticTwoPointCounter(BaseTwoPointCounter):
     """
     name = 'analytic'
 
-    def __init__(self, mode, edges, boxsize, size1=10, size2=None, los='z'):
+    def __init__(self, mode, edges, boxsize, size1=10, size2=None, los='z', selection_attrs=None):
         r"""
         Initialize :class:`AnalyticTwoPointCounter`, and set :attr:`wcounts` and :attr:`sep`.
 
@@ -1474,17 +1474,42 @@ class AnalyticTwoPointCounter(BaseTwoPointCounter):
         self._set_default_seps()
         self._set_reversible()
         self.wnorm = self.normalization()
+        self._set_selection(selection_attrs)
         self.run()
 
     def run(self):
         """Set analytical two-point counts."""
+        if any(name != "rp" for name in self.selection_attrs.keys()):
+            raise TwoPointCounterError("Analytic random counts not implemented for selections other than rp")
+        rp_selection = self.selection_attrs.get("rp", None)
+        if rp_selection is not None and self.mode not in ['s', 'smu']:
+            raise TwoPointCounterError("Analytic random counts not implemented for rp selection with mode {}".format(self.mode))
         if self.mode == 's':
             v = 4. / 3. * np.pi * self.edges[0]**3
             dv = np.diff(v, axis=0)
+            if rp_selection:
+                v_rpcut = [4. / 3. * np.pi * (self.edges[0]**3 - (self.edges[0]**2 - np.fmin(rp_cut, self.edges[0])**1.5)) for rp_cut in rp_selection]
+                v_rpcut = v_rpcut[1] - v_rpcut[0]
+                dv_rpcut = np.diff(v_rpcut, axis=0) # volume in each bin removed by rp selection
+                dv_total = dv - dv_rpcut
+                dv = np.where(dv_total >= 1e-8 * dv, dv_total, 0) # ensure that the volume is not negative and further remove small positive values that may arise due to rounding errors; assumes that dv is accurate
         elif self.mode == 'smu':
             # we bin in mu
             v = 2. / 3. * np.pi * self.edges[0][:, None]**3 * self.edges[1]
             dv = np.diff(np.diff(v, axis=0), axis=-1)
+            if rp_selection:
+                s, mu = self.edges[0][:, None], self.edges[1][None, :]
+                sin_theta = np.sqrt(1 - mu**2) * np.ones_like(s)
+                v_rpcut = []
+                for rp_cut in rp_selection:
+                    ss = s * np.ones_like(mu); c = ss * sin_theta > rp_cut; ss[c] = rp_cut / sin_theta[c] # this prevents division by zero
+                    r = ss * sin_theta
+                    h = ss * mu
+                    v_rpcut.append(2. / 3. * np.pi * (s**3 - (s**2 - r**2)**1.5 + r**2 * h))
+                v_rpcut = v_rpcut[1] - v_rpcut[0]
+                dv_rpcut = np.diff(np.diff(v_rpcut, axis=0), axis=-1) # volume in each bin removed by rp selection
+                dv_total = dv - dv_rpcut
+                dv = np.where(dv_total >= 1e-8 * dv, dv_total, 0) # ensure that the volume is not negative and further remove small positive values that may arise due to rounding errors; assumes that dv is accurate
         elif self.mode == 'rppi':
             v = np.pi * self.edges[0][:, None]**2 * self.edges[1]
             dv = np.diff(np.diff(v, axis=0), axis=1)

--- a/pycorr/twopoint_counter.py
+++ b/pycorr/twopoint_counter.py
@@ -1488,8 +1488,8 @@ class AnalyticTwoPointCounter(BaseTwoPointCounter):
             v = 4. / 3. * np.pi * self.edges[0]**3
             dv = np.diff(v, axis=0)
             if rp_selection:
-                v_rpcut = [4. / 3. * np.pi * (self.edges[0]**3 - (self.edges[0]**2 - np.fmin(rp_cut, self.edges[0])**1.5)) for rp_cut in rp_selection]
-                v_rpcut = v_rpcut[1] - v_rpcut[0]
+                v_rpcut = [4. / 3. * np.pi * (self.edges[0]**3 - (self.edges[0]**2 - np.fmin(rp_cut, self.edges[0])**2)**1.5) for rp_cut in rp_selection] # volume of the intersection of a cylinder with radius rp_cut and a sphere with radius s
+                v_rpcut = v_rpcut[1] - v_rpcut[0] # the volume that is removed between two rp cut limits
                 dv_rpcut = np.diff(v_rpcut, axis=0) # volume in each bin removed by rp selection
                 dv_total = dv - dv_rpcut
                 dv = np.where(dv_total >= 1e-8 * dv, dv_total, 0) # ensure that the volume is not negative and further remove small positive values that may arise due to rounding errors; assumes that dv is accurate
@@ -1502,11 +1502,11 @@ class AnalyticTwoPointCounter(BaseTwoPointCounter):
                 sin_theta = np.sqrt(1 - mu**2) * np.ones_like(s)
                 v_rpcut = []
                 for rp_cut in rp_selection:
-                    ss = s * np.ones_like(mu); c = ss * sin_theta > rp_cut; ss[c] = rp_cut / sin_theta[c] # this prevents division by zero
-                    r = ss * sin_theta
-                    h = ss * mu
-                    v_rpcut.append(2. / 3. * np.pi * (s**3 - (s**2 - r**2)**1.5 + r**2 * h))
-                v_rpcut = v_rpcut[1] - v_rpcut[0]
+                    ss = s * np.ones_like(mu); c = ss * sin_theta > rp_cut; ss[c] = rp_cut / sin_theta[c] # this prevents division by zero, should work when rp_cut = 0 or s = 0
+                    r = ss * sin_theta # = min(rp_cut, s * sin(theta))
+                    h = ss * mu # = cot(theta) * r, but avoids ambiguity/division by zero
+                    v_rpcut.append(2. / 3. * np.pi * (s**3 - (s**2 - r**2)**1.5 + r**2 * h)) # volume of the intersection of a cylinder with radius rp_cut and a spherical sector/cone between -1 and mu with radius s. it can be decomposed into (1) intersection of a cylinder with the sphere, (2) a usual cylinder and (3) a usual cone. r is the radius of all these things from the line of sight; h is the height of the cylinder (2) and the cone (3)
+                v_rpcut = v_rpcut[1] - v_rpcut[0] # the volume that is removed between two rp cut limits
                 dv_rpcut = np.diff(np.diff(v_rpcut, axis=0), axis=-1) # volume in each bin removed by rp selection
                 dv_total = dv - dv_rpcut
                 dv = np.where(dv_total >= 1e-8 * dv, dv_total, 0) # ensure that the volume is not negative and further remove small positive values that may arise due to rounding errors; assumes that dv is accurate

--- a/pycorr/twopoint_counter.py
+++ b/pycorr/twopoint_counter.py
@@ -1488,8 +1488,8 @@ class AnalyticTwoPointCounter(BaseTwoPointCounter):
             v = 4. / 3. * np.pi * self.edges[0]**3
             dv = np.diff(v, axis=0)
             if rp_selection:
-                v_rpcut = [4. / 3. * np.pi * (self.edges[0]**3 - (self.edges[0]**2 - np.fmin(rp_cut, self.edges[0])**2)**1.5) for rp_cut in rp_selection] # volume of the intersection of a cylinder with radius rp_cut and a sphere with radius s
-                v_rpcut = v_rpcut[0] - v_rpcut[1] # the volume that is removed between two rp cut limits
+                v_rpcut = [4. / 3. * np.pi * (self.edges[0]**3 - np.fmax(self.edges[0]**2 - rp_cut**2, 0)**1.5) for rp_cut in rp_selection] # volume of the intersection of a cylinder with radius rp_cut and a sphere with radius s
+                v_rpcut = v_rpcut[1] - v_rpcut[0] # the volume that is removed between two rp cut limits
                 dv_rpcut = np.diff(v_rpcut, axis=0) # volume in each bin removed by rp selection
                 dv = np.where(dv_rpcut >= 1e-8 * dv, dv_rpcut, 0) # ensure that the volume is not negative and further remove small positive values that may arise due to rounding errors; assumes that dv is accurate
         elif self.mode == 'smu':
@@ -1504,8 +1504,12 @@ class AnalyticTwoPointCounter(BaseTwoPointCounter):
                     ss = s * np.ones_like(mu); c = ss * sin_theta > rp_cut; ss[c] = rp_cut / sin_theta[c] # this prevents division by zero, should work when rp_cut = 0, infinity or s = 0
                     r = ss * sin_theta # = min(rp_cut, s * sin(theta))
                     h = ss * mu # = cot(theta) * r, but avoids ambiguity/division by zero
-                    v_rpcut.append(2. / 3. * np.pi * (s**3 - (s**2 - r**2)**1.5 + r**2 * h)) # volume of the intersection of a cylinder with radius rp_cut and a spherical sector/cone between -1 and mu with radius s. it can be decomposed into (1) intersection of a cylinder with the sphere, (2) a usual cylinder and (3) a usual cone. r is the radius of all these things from the line of sight; h is the height of the cylinder (2) and the cone (3)
-                v_rpcut = v_rpcut[0] - v_rpcut[1] # the volume that is removed between two rp cut limits
+                    v_rpcut.append(2. / 3. * np.pi * (s**3 - (s**2 - r**2)**1.5 + r**2 * h + 2 * (mu > 0) * ((s**2 - r**2)**1.5 - np.fmax(s**2 - rp_cut**2, 0)**1.5))) # volume of the intersection of a cylinder with radius rp_cut and a spherical sector/cone between -1 and mu with radius s.
+                    # it can be decomposed into (1) intersection of a cylinder with the sphere, (2) a usual cylinder, (3) a usual cone and (4) only for mu>0 - intersection of the sphere with the space between two cylinders.
+                    # r is the radius of (1-3) from the line of sight; h is the height of the cylinder (2) and the cone (3).
+                    # the radii of cylinders for (4) are r and R = min(rp_cut, s), and r <= R always.
+                    # it may seem that (4) becomes a more complicated shape if r < s * sin(theta), but this can only happen if rp_cut < s * sin(theta) <= s, then r = R = rp_cut, and we obtain zero volume as it should be.
+                v_rpcut = v_rpcut[1] - v_rpcut[0] # the volume that is removed between two rp cut limits
                 dv_rpcut = np.diff(np.diff(v_rpcut, axis=0), axis=-1) # volume in each bin removed by rp selection
                 dv = np.where(dv_rpcut >= 1e-8 * dv, dv_rpcut, 0) # ensure that the volume is not negative and further remove small positive values that may arise due to rounding errors; assumes that dv is accurate
         elif self.mode == 'rppi':

--- a/pycorr/twopoint_counter.py
+++ b/pycorr/twopoint_counter.py
@@ -1489,10 +1489,9 @@ class AnalyticTwoPointCounter(BaseTwoPointCounter):
             dv = np.diff(v, axis=0)
             if rp_selection:
                 v_rpcut = [4. / 3. * np.pi * (self.edges[0]**3 - (self.edges[0]**2 - np.fmin(rp_cut, self.edges[0])**2)**1.5) for rp_cut in rp_selection] # volume of the intersection of a cylinder with radius rp_cut and a sphere with radius s
-                v_rpcut = v_rpcut[1] - v_rpcut[0] # the volume that is removed between two rp cut limits
+                v_rpcut = v_rpcut[0] - v_rpcut[1] # the volume that is removed between two rp cut limits
                 dv_rpcut = np.diff(v_rpcut, axis=0) # volume in each bin removed by rp selection
-                dv_total = dv - dv_rpcut
-                dv = np.where(dv_total >= 1e-8 * dv, dv_total, 0) # ensure that the volume is not negative and further remove small positive values that may arise due to rounding errors; assumes that dv is accurate
+                dv = np.where(dv_rpcut >= 1e-8 * dv, dv_rpcut, 0) # ensure that the volume is not negative and further remove small positive values that may arise due to rounding errors; assumes that dv is accurate
         elif self.mode == 'smu':
             # we bin in mu
             v = 2. / 3. * np.pi * self.edges[0][:, None]**3 * self.edges[1]
@@ -1502,14 +1501,13 @@ class AnalyticTwoPointCounter(BaseTwoPointCounter):
                 sin_theta = np.sqrt(1 - mu**2) * np.ones_like(s)
                 v_rpcut = []
                 for rp_cut in rp_selection:
-                    ss = s * np.ones_like(mu); c = ss * sin_theta > rp_cut; ss[c] = rp_cut / sin_theta[c] # this prevents division by zero, should work when rp_cut = 0 or s = 0
+                    ss = s * np.ones_like(mu); c = ss * sin_theta > rp_cut; ss[c] = rp_cut / sin_theta[c] # this prevents division by zero, should work when rp_cut = 0, infinity or s = 0
                     r = ss * sin_theta # = min(rp_cut, s * sin(theta))
                     h = ss * mu # = cot(theta) * r, but avoids ambiguity/division by zero
                     v_rpcut.append(2. / 3. * np.pi * (s**3 - (s**2 - r**2)**1.5 + r**2 * h)) # volume of the intersection of a cylinder with radius rp_cut and a spherical sector/cone between -1 and mu with radius s. it can be decomposed into (1) intersection of a cylinder with the sphere, (2) a usual cylinder and (3) a usual cone. r is the radius of all these things from the line of sight; h is the height of the cylinder (2) and the cone (3)
-                v_rpcut = v_rpcut[1] - v_rpcut[0] # the volume that is removed between two rp cut limits
+                v_rpcut = v_rpcut[0] - v_rpcut[1] # the volume that is removed between two rp cut limits
                 dv_rpcut = np.diff(np.diff(v_rpcut, axis=0), axis=-1) # volume in each bin removed by rp selection
-                dv_total = dv - dv_rpcut
-                dv = np.where(dv_total >= 1e-8 * dv, dv_total, 0) # ensure that the volume is not negative and further remove small positive values that may arise due to rounding errors; assumes that dv is accurate
+                dv = np.where(dv_rpcut >= 1e-8 * dv, dv_rpcut, 0) # ensure that the volume is not negative and further remove small positive values that may arise due to rounding errors; assumes that dv is accurate
         elif self.mode == 'rppi':
             v = np.pi * self.edges[0][:, None]**2 * self.edges[1]
             dv = np.diff(np.diff(v, axis=0), axis=1)


### PR DESCRIPTION
In my project, I was computing correlation functions in periodic boxes with rp cut and realized the analytic RR counts did not account for that, causing a dip in the correlation function monopole. I derived the rp cut correction for the counts analytically (geometrically) and coded it, although additional testing would probably be needed.