### PR TITLE
Box subsampler fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ doc/_build/
 
 # Unit test / coverage reports
 **/.coverage
+
+# the annoying macOS hidden file
+.DS_Store

--- a/pycorr/tests/test_twopoint_jackknife.py
+++ b/pycorr/tests/test_twopoint_jackknife.py
@@ -57,8 +57,9 @@ def test_subsampler():
     assert np.max(labels) < nsamples
 
     # more accurate test for the labeling
-    coordinates_1d = np.linspace(0, boxsize_1d, 2 * nsamples_1d + 1)[1::2] # in the middle of the parts along each dimension, with no shift to make things easier here
-    labels_1d = np.arange(nsamples_1d) # obvious regions along each axis
+    points_per_part = 5 # how many points to put into each part along each coordinates (so that each regions will contain points_per_part**3 points)
+    coordinates_1d = np.linspace(0, boxsize_1d, 2 * points_per_part * nsamples_1d + 1)[1::2] # in the middle of the parts along each dimension, with no shift to make things easier here
+    labels_1d = np.repeat(np.arange(nsamples_1d), points_per_part) # obvious regions along each axis
     coordinates_alt = [np.ravel(_) for _ in np.meshgrid(coordinates_1d, coordinates_1d, coordinates_1d, indexing = 'ij')] # arrays of all 3D coordinate combinations taken from `coordinates_1d`
     labels_3d = [np.ravel(_) for _ in np.meshgrid(labels_1d, labels_1d, labels_1d, indexing = 'ij')] # arrays of all 3D index combinations taken from `labels_1d`, same order as the coordinates
     labels_alt = sum(_ * nsamples_1d ** i for (i, _) in enumerate(labels_3d[::-1])) # more explicit conversion to the multi-dimensional index

--- a/pycorr/tests/test_twopoint_jackknife.py
+++ b/pycorr/tests/test_twopoint_jackknife.py
@@ -58,13 +58,13 @@ def test_subsampler():
 
     # more accurate test for the labeling
     points_per_part = 5 # how many points to put into each part along each coordinates (so that each regions will contain points_per_part**3 points)
-    coordinates_1d = np.linspace(0, boxsize_1d, 2 * points_per_part * nsamples_1d + 1)[1::2] # in the middle of the parts along each dimension, with no shift to make things easier here
+    coordinates_1d = np.linspace(0, boxsize_1d, 2 * points_per_part * nsamples_1d + 1)[1::2] # in the middle of the parts along each dimension (avoiding the very edges which can be ambiguous), with no shift to make things easier here
     labels_1d = np.repeat(np.arange(nsamples_1d), points_per_part) # obvious regions along each axis
     coordinates_alt = [np.ravel(_) for _ in np.meshgrid(coordinates_1d, coordinates_1d, coordinates_1d, indexing = 'ij')] # arrays of all 3D coordinate combinations taken from `coordinates_1d`
     labels_3d = [np.ravel(_) for _ in np.meshgrid(labels_1d, labels_1d, labels_1d, indexing = 'ij')] # arrays of all 3D index combinations taken from `labels_1d`, same order as the coordinates
     labels_alt = sum(_ * nsamples_1d ** i for (i, _) in enumerate(labels_3d[::-1])) # more explicit conversion to the multi-dimensional index
     assert np.max(labels_alt) == nsamples - 1
-    subsampler2 = BoxSubsampler(boxsize=boxsize, boxcenter=boxsize/2, nsamples=nsamples) # subsampler without shift
+    subsampler2 = BoxSubsampler(boxsize=boxsize_1d, boxcenter=boxsize_1d/2, nsamples=nsamples) # subsampler for a strictly cubic box without shift
     assert np.array_equal(subsampler2.label(coordinates_alt, position_type = 'xyz'), labels_alt)
 
     if mpi:

--- a/pycorr/twopoint_jackknife.py
+++ b/pycorr/twopoint_jackknife.py
@@ -172,7 +172,7 @@ class BoxSubsampler(BaseSubsampler):
             self.nsamples = tuple(nsamples)
         else:
             nsamples = int(nsamples)
-            self.nsamples = (int(nsamples**(1. / ndim) + 0.5),) * ndim
+            self.nsamples = (int(np.rint(nsamples**(1. / ndim))),) * ndim
             if nsamples != np.prod(self.nsamples):
                 raise ValueError('Number of regions must be a {:d}-th power of an integer'.format(ndim))
 

--- a/pycorr/twopoint_jackknife.py
+++ b/pycorr/twopoint_jackknife.py
@@ -214,7 +214,7 @@ class BoxSubsampler(BaseSubsampler):
             if not np.all((tmp >= 0) & (tmp < len(edge) - 1)):
                 raise ValueError('Some input positions outside of bounding box')
             ii.append(tmp)
-        return np.ravel_multi_index(tuple(ii), tuple(len(edge) - 1 for edge in self.edges), mode='raise', order='C')
+        return np.ravel_multi_index(tuple(ii), self.nsamples, mode='raise', order='C')
 
 
 class KMeansSubsampler(BaseSubsampler):

--- a/pycorr/twopoint_jackknife.py
+++ b/pycorr/twopoint_jackknife.py
@@ -130,8 +130,8 @@ class BoxSubsampler(BaseSubsampler):
                 - "pos": Cartesian positions, shape (N, 3).
 
         wrap : bool, default=False
-            Whether to wrap input positions in [0, boxsize[?
-            If ``False`` and input positions do not fit in the the box size, raise a :class:`ValueError`.
+            Whether to wrap input positions in [boxcenter - boxsize/2, boxcenter + boxsize/2).
+            If ``False`` and input positions do not fit in that range, raise a :class:`ValueError`.
 
         dtype : string, np.dtype, default=None
             Array type for positions and weights.

--- a/pycorr/twopoint_jackknife.py
+++ b/pycorr/twopoint_jackknife.py
@@ -169,9 +169,12 @@ class BoxSubsampler(BaseSubsampler):
         if isinstance(nsamples, (list, tuple)):
             if len(nsamples) != ndim:
                 raise ValueError('nsamples must be a list/tuple of size {:d}'.format(ndim))
+            if any(not isinstance(_, int) for _ in nsamples): raise TypeError('nsamples must be an integer or a list/tuple of integers')
+            if any(_ <= 0 for _ in nsamples): raise ValueError('nsamples must be a list/tuple of positive elements')
             self.nsamples = tuple(nsamples)
         else:
-            nsamples = int(nsamples)
+            if not isinstance(nsamples, int): raise TypeError('nsamples must be an integer')
+            if nsamples <= 0: raise ValueError('nsamples must be positive')
             self.nsamples = (int(np.rint(nsamples**(1. / ndim))),) * ndim
             if nsamples != np.prod(self.nsamples):
                 raise ValueError('Number of regions must be a {:d}-th power of an integer'.format(ndim))

--- a/pycorr/twopoint_jackknife.py
+++ b/pycorr/twopoint_jackknife.py
@@ -181,7 +181,7 @@ class BoxSubsampler(BaseSubsampler):
     def run(self):
         """Set edges for binning along each axis."""
         offset = self.boxcenter - self.boxsize / 2.
-        self.edges = [o + np.linspace(0, b, n) for o, b, n in zip(offset, self.boxsize, self.nsamples)]
+        self.edges = [o + np.linspace(0, b, n + 1) for o, b, n in zip(offset, self.boxsize, self.nsamples)]
 
     def label(self, positions, position_type=None):
         """


### PR DESCRIPTION
The `BoxSubsampler` currently creates 1 fewer region than expected along each axis, according to `pycorr/twopoint_jackknife:184`: `self.edges = [o + np.linspace(0, b, n) for o, b, n in zip(offset, self.boxsize, self.nsamples)]`. The fix for that is quite trivial, but it raises a question of why tests have not revealed this issue.